### PR TITLE
Add overload to Bitmap.Flush() accepting bitmap and screen coordinates

### DIFF
--- a/nanoFramework.Graphics/Primitive/Bitmap.cs
+++ b/nanoFramework.Graphics/Primitive/Bitmap.cs
@@ -197,20 +197,32 @@ namespace nanoFramework.UI
 
         /// <summary>
         /// Flushes the current bitmap to the display device.
-        /// The bitmap must have the same dimensions as the display device.The.NET Micro Framework provides the
+        /// Bitmap will be written to the upper-left corner of the screen (full-screen, for full-screen bitmaps).
         /// </summary>
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         extern public void Flush();
 
         /// <summary>
-        /// Flushes the current bitmap to the display device.
+        /// Flushes a sub-rectangle of the current bitmap to the display device.
         /// </summary>
-        /// <param name = "x" > The x-coordinate of the bitmap's upper-left corner.</param>
-        /// <param name = "y" > The y-coordinate of the bitmap's upper-left corner.</param>
-        /// <param name = "width" > The width of the bitmap.</param>
-        /// <param name = "height" > The height of the bitmap.</param>
+        /// <param name = "x" > The x-coordinate of the sub-rectangle's upper-left corner.</param>
+        /// <param name = "y" > The y-coordinate of the sub-rectangle's upper-left corner.</param>
+        /// <param name = "width" > The width of the sub-rectangle.</param>
+        /// <param name = "height" > The height of the sub-rectangle.</param>
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         extern public void Flush(int x, int y, int width, int height);
+
+        /// <summary>
+        /// Flushes a sub-rectangle of the current bitmap to the display device at a specified screen position.
+        /// </summary>
+        /// <param name = "srcX" > The x-coordinate of the sub-rectangle's upper-left corner.</param>
+        /// <param name = "srcY" > The y-coordinate of the sub-rectangle's upper-left corner.</param>
+        /// <param name = "width" > The width of the sub-rectangle.</param>
+        /// <param name = "height" > The height of the sub-rectangle.</param>
+        /// <param name = "screenX" > The x-coordinate of the screen to write to.</param>
+        /// <param name = "screenY" > The y-coordinate of the screen to write to</param>
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        extern public void Flush(int srcX, int srcY, int width, int height, int screenX, int screenY);
 
         /// <summary>
         /// Clears the entire drawing surface.

--- a/nanoFramework.Graphics/Properties/AssemblyInfo.cs
+++ b/nanoFramework.Graphics/Properties/AssemblyInfo.cs
@@ -11,7 +11,7 @@ using System.Runtime.InteropServices;
 
 ////////////////////////////////////////////////////////////////
 // update this whenever the native assembly signature changes //
-[assembly: AssemblyNativeVersion("100.0.0.3")]
+[assembly: AssemblyNativeVersion("100.0.0.4")]
 ////////////////////////////////////////////////////////////////
 
 // Setting ComVisible to false makes the types in this assembly not visible 


### PR DESCRIPTION
<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
A new overload was added to the managed interface for Bitmap Flush() to allow bitmap and screen coordinates to be specified separately.

## Motivation and Context
Previously there was no way to separately specify sub-rectangle x/y coordinates and screen x/y coordinates when flushing a bitmap to the screen. Support for this has been added to the native graphics code (see https://github.com/nanoframework/nf-interpreter/pull/2341 for the PR for the native code).

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
Tested locally on an M5Stack Core2 by building both the native target and using the new managed assembly.

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
