### PR TITLE
Added DrawChar to Bitmap

### DIFF
--- a/nanoFramework.Graphics/Primitive/Bitmap.cs
+++ b/nanoFramework.Graphics/Primitive/Bitmap.cs
@@ -268,7 +268,7 @@ namespace nanoFramework.UI
         }
 
         /// <summary>
-        /// Draws a single character to the screen
+        /// Draws a single character to the screen.
         /// </summary>
         /// <param name="c"> The character to draw.</param>
         /// <param name="x"> The x-coordinate of the upper-left corner to draw to.</param>

--- a/nanoFramework.Graphics/Primitive/Bitmap.cs
+++ b/nanoFramework.Graphics/Primitive/Bitmap.cs
@@ -268,6 +268,17 @@ namespace nanoFramework.UI
         }
 
         /// <summary>
+        /// Draws a single character to the screen
+        /// </summary>
+        /// <param name="c"> The character to draw.</param>
+        /// <param name="x"> The x-coordinate of the upper-left corner to draw to.</param>
+        /// <param name="y"> The y-coordinate of the upper-left corner to draw to.</param>
+        /// <param name="color"> The color to be used for the character.</param>
+        /// <param name="font"> The font to be used for the character.</param>
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        extern public void DrawChar(ushort c, int x, int y, Color color, Font font);
+
+        /// <summary>
         /// 
         /// </summary>
         /// <param name = "x" > The x-coordinate of the upper-left corner of the clipping rectangle.</param>

--- a/nanoFramework.Graphics/Properties/AssemblyInfo.cs
+++ b/nanoFramework.Graphics/Properties/AssemblyInfo.cs
@@ -11,7 +11,7 @@ using System.Runtime.InteropServices;
 
 ////////////////////////////////////////////////////////////////
 // update this whenever the native assembly signature changes //
-[assembly: AssemblyNativeVersion("100.0.0.4")]
+[assembly: AssemblyNativeVersion("100.0.0.5")]
 ////////////////////////////////////////////////////////////////
 
 // Setting ComVisible to false makes the types in this assembly not visible 


### PR DESCRIPTION
<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
This change adds a DrawChar method to the Bitmap class.

## Motivation and Context
See corresponding nf-interpreter PR here: https://github.com/nanoframework/nf-interpreter/pull/2390

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
Tested locally on M5Stack Core2.

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
