### PR TITLE
Fixing incorrect Gc9A01 references in code doc

### DIFF
--- a/ManagedDrivers/Ili9341/Ili9341.cs
+++ b/ManagedDrivers/Ili9341/Ili9341.cs
@@ -85,7 +85,7 @@ namespace nanoFramework.UI.GraphicDrivers
         public static ushort Height { get; } = 320;
 
         /// <summary>
-        /// Gets the graphic driver for the Gc9A01 display.
+        /// Gets the graphic driver for the Ili9341 display.
         /// </summary>
         public static GraphicDriver GraphicDriver
         {
@@ -202,7 +202,7 @@ namespace nanoFramework.UI.GraphicDrivers
         }
 
         /// <summary>
-        /// Gets the graphic driver without adjusting the manufacturer default settings for the Gc9A01 display.
+        /// Gets the graphic driver without adjusting the manufacturer default settings for the Ili9341 display.
         /// Use this driver when you are unsure first.
         /// </summary>
         public static GraphicDriver GraphicDriverWithDefaultManufacturingSettings

--- a/ManagedDrivers/Ili9342/Ili9342.cs
+++ b/ManagedDrivers/Ili9342/Ili9342.cs
@@ -7,7 +7,7 @@
 namespace nanoFramework.UI.GraphicDrivers
 {
     /// <summary>
-    /// Managed driver for GC9A01.
+    /// Managed driver for Ili9342.
     /// </summary>
     public static class Ili9342
     {
@@ -79,7 +79,7 @@ namespace nanoFramework.UI.GraphicDrivers
         public static uint Height { get; } = 240;
 
         /// <summary>
-        /// Gets the graphic driver for the Gc9A01 display.
+        /// Gets the graphic driver for the Ili9342 display.
         /// </summary>
         public static GraphicDriver GraphicDriver
         {

--- a/ManagedDrivers/Otm8009A/Otm8009A.cs
+++ b/ManagedDrivers/Otm8009A/Otm8009A.cs
@@ -44,7 +44,7 @@ namespace nanoFramework.UI.GraphicDrivers
         public static ushort Height { get; } = 480;
 
         /// <summary>
-        /// Gets the graphic driver for the Gc9A01 display.
+        /// Gets the graphic driver for the Otm8009A display.
         /// </summary>
         public static GraphicDriver GraphicDriver
         {


### PR DESCRIPTION
## Description
Fixing incorrect Gc9A01 references in code doc

## Motivation and Context
Fixing incorrect Gc9A01 references in code doc

## Types of changes
- [X] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
- [X] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
